### PR TITLE
🐛 修复了纯文字章节引发的错误

### DIFF
--- a/main.py
+++ b/main.py
@@ -66,7 +66,13 @@ if __name__ == '__main__':
         point_list = chaoxing.get_course_point(course["courseId"], course["clazzId"], course["cpi"])
         for point in point_list["points"]:
             # 获取当前章节的所有任务点
-            jobs, job_info = chaoxing.get_job_list(course["clazzId"], course["courseId"], course["cpi"], point["id"])
+            jobs=[]
+            job_info = None 
+            try:
+                jobs,job_info = chaoxing.get_job_list(course["clazzId"], course["courseId"], course["cpi"], point["id"])
+            except:
+                logger.warning(f"跳过错误章节 -> {point['title']}")
+        
             # 可能存在章节无任何内容的情况
             if not jobs:
                 continue


### PR DESCRIPTION
#301 的错误原因似乎就是出现了类似于这样的纯文字章节，我使用了一个try来尝试忽略这种章节

```python
jobs=[]
job_info = None 
try:
    jobs,job_info = chaoxing.get_job_list(course["clazzId"], course["courseId"], course["cpi"], point["id"])
except:
    logger.warning(f"跳过错误章节 -> {point['title']}")
```

![image](https://github.com/Samueli924/chaoxing/assets/88923783/aa64c203-cd08-4ab1-a45d-422942d6bccd)
