### PR TITLE
feat: 支持通过调用AI大模型进行答题

### DIFF
--- a/api/answer.py
+++ b/api/answer.py
@@ -6,6 +6,7 @@ from api.logger import logger
 import random
 from urllib3 import disable_warnings,exceptions
 from openai import OpenAI
+import httpx
 # 关闭警告
 disable_warnings(exceptions.InsecureRequestWarning)
 
@@ -282,7 +283,12 @@ class AI(Tiku):
         self.name = 'AI大模型答题'
 
     def _query(self, q_info: dict):
-        client = OpenAI(base_url = self.endpoint,api_key = self.key)
+        if self.http_proxy:
+            proxy = self.http_proxy
+            httpx_client = httpx.Client(proxy=proxy)
+            client = OpenAI(http_client=httpx_client, base_url = self.endpoint,api_key = self.key)
+        else:
+            client = OpenAI(base_url = self.endpoint,api_key = self.key)
         # 判断题目类型
         if q_info['type'] == "single":
             completion = client.chat.completions.create(
@@ -367,3 +373,4 @@ class AI(Tiku):
         self.endpoint = self._conf['endpoint']
         self.key = self._conf['key']
         self.model = self._conf['model']
+        self.http_proxy = self._conf['http_proxy']

--- a/api/answer.py
+++ b/api/answer.py
@@ -5,6 +5,7 @@ import json
 from api.logger import logger
 import random
 from urllib3 import disable_warnings,exceptions
+from openai import OpenAI
 # 关闭警告
 disable_warnings(exceptions.InsecureRequestWarning)
 
@@ -273,3 +274,96 @@ class TikuAdapter(Tiku):
     def _init_tiku(self):
         # self.load_token()
         self.api = self._conf['url']
+
+class AI(Tiku):
+    # AI大模型答题实现
+    def __init__(self) -> None:
+        super().__init__()
+        self.name = 'AI大模型答题'
+
+    def _query(self, q_info: dict):
+        client = OpenAI(base_url = self.endpoint,api_key = self.key)
+        # 判断题目类型
+        if q_info['type'] == "single":
+            completion = client.chat.completions.create(
+                model = self.model,
+                messages=[
+                    {
+                        "role": "system", 
+                        "content": "本题为单选题，你只能选择一个选项，请根据题目和选项回答问题，以json格式输出正确的选项内容，特别注意回答的内容需要去除选项内容前的字母，示例回答：{\"Answer\": [\"答案\"]}。除此之外不要输出任何多余的内容。如果你使用了互联网搜索，也请不要返回搜索的结果和参考资料"
+                    },
+                    {
+                        "role": "user",
+                        "content": f"题目：{q_info['title']}\n选项：{q_info['options']}"
+                    }
+                ]
+            )
+        elif q_info['type'] == 'multiple':
+            completion = client.chat.completions.create(
+                model = self.model,
+                messages=[
+                    {
+                        "role": "system", 
+                        "content": "本题为多选题，你必须选择两个或以上选项，请根据题目和选项回答问题，以json格式输出正确的选项内容，特别注意回答的内容需要去除选项内容前的字母，示例回答：{\"Answer\": [\"答案1\",\n\"答案2\",\n\"答案3\"]}。除此之外不要输出任何多余的内容。如果你使用了互联网搜索，也请不要返回搜索的结果和参考资料"
+                    },
+                    {
+                        "role": "user",
+                        "content": f"题目：{q_info['title']}\n选项：{q_info['options']}"
+                    }
+                ]
+            )
+        elif q_info['type'] == 'completion':
+            completion = client.chat.completions.create(
+                model = self.model,
+                messages=[
+                    {
+                        "role": "system", 
+                        "content": "本题为填空题，你必须根据语境和相关知识填入合适的内容，请根据题目回答问题，以json格式输出正确的答案，示例回答：{\"Answer\": [\"答案\"]}。除此之外不要输出任何多余的内容。如果你使用了互联网搜索，也请不要返回搜索的结果和参考资料"
+                    },
+                    {
+                        "role": "user",
+                        "content": f"题目：{q_info['title']}"
+                    }
+                ]
+            )
+        elif q_info['type'] == 'judgement':
+            completion = client.chat.completions.create(
+                model = self.model,
+                messages=[
+                    {
+                        "role": "system", 
+                        "content": "本题为判断题，你只能回答正确或者错误，请根据题目回答问题，以json格式输出正确的答案，示例回答：{\"Answer\": [\"正确\"]}。除此之外不要输出任何多余的内容。如果你使用了互联网搜索，也请不要返回搜索的结果和参考资料"
+                    },
+                    {
+                        "role": "user",
+                        "content": f"题目：{q_info['title']}"
+                    }
+                ]
+            )
+        else:
+            completion = client.chat.completions.create(
+                model = self.model,
+                messages=[
+                    {
+                        "role": "system", 
+                        "content": "本题为简答题，你必须根据语境和相关知识填入合适的内容，请根据题目回答问题，以json格式输出正确的答案，示例回答：{\"Answer\": [\"这是我的答案\"]}。除此之外不要输出任何多余的内容。如果你使用了互联网搜索，也请不要返回搜索的结果和参考资料"
+                    },
+                    {
+                        "role": "user",
+                        "content": f"题目：{q_info['title']}"
+                    }
+                ]
+            )
+
+        try:
+            response = json.loads(completion.choices[0].message.content)
+            sep = "\n"
+            return sep.join(response['Answer']).strip()
+        except:
+            logger.error("无法解析大模型输出内容")
+            return None
+
+    def _init_tiku(self):
+        self.endpoint = self._conf['endpoint']
+        self.key = self._conf['key']
+        self.model = self._conf['model']

--- a/api/base.py
+++ b/api/base.py
@@ -457,9 +457,11 @@ class Chaoxing:
                         if res in o:
                             answer = o[:1]
                             break
-                # 如果未能匹配, 依然随机答题
-                logger.info(f"找到答案但答案未能匹配 -> {res}\t随机选择答案")
-                answer = answer if answer else random_answer(q["options"])
+                if not answer:  # 检查 answer 是否为空
+                    logger.warning(f"找到答案但答案未能匹配 -> {res}\t随机选择答案")
+                    answer = random_answer(q["options"])  # 如果为空，则随机选择答案
+                else:
+                    logger.info(f"成功获取到答案：{answer}")
             # 填充答案
             q["answerField"][f'answer{q["id"]}'] = answer
             logger.info(f'{q["title"]} 填写答案为 {answer}')

--- a/config_template.ini
+++ b/config_template.ini
@@ -29,6 +29,8 @@ url=
 endpoint=
 key=
 model=
+; 可选配置请求大模型时使用的代理，填写示例：http://examples.com
+http_proxy=
 ; 用于判断判断题对应的选项，不要留有空格，不要留有引号，逗号为英文逗号
 true_list=正确,对,√,是
 false_list=错误,错,×,否,不对,不正确

--- a/config_template.ini
+++ b/config_template.ini
@@ -14,6 +14,7 @@ speed = 1
 ; 可选项 :
 ; 1. TikuYanxi(言溪题库 https://tk.enncy.cn/)
 ; 2. TikuAdapter(开源项目 https://github.com/DokiDoki1103/tikuAdapter)
+; 3. AI(需自行寻找兼容openai格式的API Endpoint和Key)
 provider=TikuYanxi
 ; 是否直接提交答题，填写false表示答完题后不提交而是保存，随后你可以自行前往学习通修改或提交
 ; 填写true表示直接提交，不保证正确率！不正确的填写会被视为false
@@ -23,6 +24,11 @@ submit=false
 tokens=
 ; 用于TikuAdapter题库的url
 url=
+; 用于AI大模型答题的API Endpoint和Key
+; 请注意API Endpoint可能需要带上/v1路径，例如: https://example.com/v1
+endpoint=
+key=
+model=
 ; 用于判断判断题对应的选项，不要留有空格，不要留有引号，逗号为英文逗号
 true_list=正确,对,√,是
 false_list=错误,错,×,否,不对,不正确

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ loguru
 celery
 flask
 fonttools
+openai


### PR DESCRIPTION
添加AI大模型答题能力，作为除了配置题库以外的第二种答题方式  
兼容OpenAI格式，使用时需自行在`config.ini`中配置API Endpoint, API Key和模型名称  
同时优化`base.py`中的答案检查逻辑，先前无论`answer`是否为空均会提示“找到答案但答案未能匹配”