### PR TITLE
增加对于教师未完成测验情况的过滤与对题目未进行加密情况的处理

### DIFF
--- a/api/base.py
+++ b/api/base.py
@@ -427,6 +427,12 @@ class Chaoxing:
             },
         )
         _ORIGIN_HTML_CONTENT = _resp.text  # 用于配合输出网页源码, 帮助修复#391错误
+
+        # 未创建完成该测验则不进行答题，目前遇到的情况是未创建完成等同于没题目
+        if '教师未创建完成该测验' in _resp.text: 
+            logger.warning(f'教师未创建完成该测验')
+            return 0
+        
         questions = decode_questions_info(_resp.text)  # 加载题目信息
 
         # 搜题


### PR DESCRIPTION
修复了 #407 和 #403 中提到的 `AttributeError: 'NoneType' object has no attribute 'text'` 问题
该问题是因为题目中不含有中文，返回的数据中就不会有加密字体的数据，然后就引发了报错。
具体的修复就是在 `apt/base.py` 中检索一下“教师未完成测验情况”字符串，然后在 `api/decode.py` 中对未加密题目直接提取。