### PR TITLE
feat: 使用 pyproject.toml 锁定依赖版本

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,6 +133,10 @@ build/
 dist/
 *.spec
 
+# python-uv.lock
+# just like Pipfile.lock,
+uv.lock
+
 # Custom files
 .cookies.txt
 cookies.txt

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 ### 源码运行
 1. `git clone --depth=1 https://github.com/Samueli924/chaoxing` 项目至本地
 2. `cd chaoxing`
-3. `pip install -r requirements.txt`
+3. `pip install -r requirements.txt` 或者 `pip install .`(通过 pyproject.toml 安装依赖)
 4. (可选直接运行) `python main.py`
 5. (可选配置文件运行) 复制config_template.ini文件为config.ini文件，修改文件内的账号密码内容, 执行 `python main.py -c config.ini`
 6. (可选命令行运行)`python main.py -u 手机号 -p 密码 -l 课程ID1,课程ID2,课程ID3...(可选)`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "chaoxing"
+version = "3.1.1"
+description = "超星学习通/超星尔雅/泛雅超星全自动无人值守完成任务点"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "argparse>=1.4.0",
+    "beautifulsoup4>=4.13.3",
+    "celery>=5.4.0",
+    "flask>=3.1.0",
+    "fonttools>=4.56.0",
+    "loguru>=0.7.3",
+    "lxml>=5.3.1",
+    "openai>=1.66.2",
+    "pyaes>=1.6.1",
+    "requests>=2.32.3",
+]


### PR DESCRIPTION
使用 `pyproject.toml` 的理由如下：
- 方便开发者复现相同的开发环境
- pytest、black、isort等常用工具都支持pyproject.toml了，可以实现一个文件完成全项目的配置
- 越来越多的开源项目使用`pyproject.toml`