### PR TITLE
fix: 题目与选项中无法识别图片

### DIFF
--- a/api/base.py
+++ b/api/base.py
@@ -620,10 +620,10 @@ class Chaoxing:
             if res_json["status"]:
                 logger.info(f'{"提交" if questions["pyFlag"] == "" else "保存"}答题成功 -> {res_json["msg"]}')
             else:
-                logger.error(f'{"提交" if questions["pyFlag"] == "" else "保存"}提交答题失败 -> {res_json["msg"]}')
+                logger.error(f'{"提交" if questions["pyFlag"] == "" else "保存"}答题失败 -> {res_json["msg"]}')
                 return self.StudyResult.ERROR
         else:
-            logger.error(f'{"提交" if questions["pyFlag"] == "" else "保存"}提交答题失败 -> {res.text}')
+            logger.error(f'{"提交" if questions["pyFlag"] == "" else "保存"}答题失败 -> {res.text}')
             return self.StudyResult.ERROR
         return self.StudyResult.SUCCESS
 

--- a/api/notification.py
+++ b/api/notification.py
@@ -23,7 +23,7 @@ class Notification:
 
     def _get_conf(self):
         """
-            从默认配置文件查询配置, 如果未能查到, 停用题库
+            从默认配置文件查询配置, 如果未能查到, 停用外部通知功能
         """
         try:
             config = configparser.ConfigParser()


### PR DESCRIPTION
看了几个脚本
一般是用这两种方式放入图片，我选择了第一种
```
1.把函数<img src="https://p.ananas.chaoxing.com/star3/origin/fcd0*********"/>展开为傅里叶级数（ ）
2.把函数https://p.ananas.chaoxing.com/star3/origin/fcd0*****展开为傅里叶级数（ ）
```
至于各题库对于图片的支持，我不好说
如果需要转换，个人认为第一种方式容易转换为第二种一些，所以选择了第一种

或者说是否有需要将两种方式的标题都给出，让题库选择
如有建议，烦请指出
#457 #447 