### PR TITLE
fix: 添加对span.bntHoverTips元素存在性的判断

### DIFF
--- a/api/decode.py
+++ b/api/decode.py
@@ -84,9 +84,9 @@ def decode_course_point(_text):
                 ).attrs["value"]
             else:
                 # 判断是不是因为需要解锁
-                if "解锁" in _point.select_one("span.bntHoverTips").text:
+                if _point.select_one("span.bntHoverTips") and "解锁" in _point.select_one("span.bntHoverTips").text:
                     _course_point["hasLocked"] = True
-            if "已完成" in _point.select_one("span.bntHoverTips").text:
+            if _point.select_one("span.bntHoverTips") and "已完成" in _point.select_one("span.bntHoverTips").text:
                 _point_detail["has_finished"] = True
             else:
                 _point_detail["has_finished"] = False


### PR DESCRIPTION
添加对span.bntHoverTips元素存在性的判断，避免直接访问.text属性导致NoneType错误

Bug细节
![Screenshot 2025-05-17 063831](https://github.com/user-attachments/assets/d3499a9d-bf1e-47d2-9d40-ccc7e561bcd9)
![Screenshot 2025-05-17 063931](https://github.com/user-attachments/assets/aa417527-6196-4410-a096-38169afeb2ab)
![Screenshot 2025-05-17 063953](https://github.com/user-attachments/assets/a25776a2-abcd-489b-a7b2-21d015b12ca0)
发现是由于不存在span.bntHoverTips元素引发AttributeError: 'NoneType' object has no attribute 'text'