### PR TITLE
硅基流动增加了token的限制防止在Deepseek-r1模型下答题失败

### DIFF
--- a/api/answer.py
+++ b/api/answer.py
@@ -22,7 +22,7 @@ class CacheDAO:
     @Author: SocialSisterYi
     @Reference: https://github.com/SocialSisterYi/xuexiaoyi-to-xuexitong-tampermonkey-proxy
     """
-    DEFAULT_CACHE_FILE = "../cache.json"
+    DEFAULT_CACHE_FILE = "cache.json"
 
     def __init__(self, file: str = DEFAULT_CACHE_FILE):
         self.cache_file = Path(file)
@@ -512,6 +512,7 @@ class AI(Tiku):
         self.model = self._conf['model']
         self.http_proxy = self._conf['http_proxy']
         self.min_interval_seconds = int(self._conf['min_interval_seconds'])
+        
 class SiliconFlow(Tiku):
     """硅基流动大模型答题实现"""
     def __init__(self):
@@ -557,7 +558,7 @@ class SiliconFlow(Tiku):
                 }
             ],
             "stream": False,
-            "max_tokens": 512,
+            "max_tokens": 4096,
             "temperature": 0.7,
             "top_p": 0.7,
             "response_format": {"type": "text"}
@@ -595,5 +596,5 @@ class SiliconFlow(Tiku):
         # 从配置文件读取参数
         self.api_endpoint = self._conf.get('siliconflow_endpoint', 'https://api.siliconflow.cn/v1/chat/completions')
         self.api_key = self._conf['siliconflow_key']
-        self.model_name = self._conf.get('siliconflow_model', 'deepseek-ai/DeepSeek-R1')
+        self.model_name = self._conf.get('siliconflow_model', 'deepseek-ai/DeepSeek-V3')
         self.min_interval = int(self._conf.get('min_interval_seconds', 3))

--- a/api/answer.py
+++ b/api/answer.py
@@ -22,7 +22,7 @@ class CacheDAO:
     @Author: SocialSisterYi
     @Reference: https://github.com/SocialSisterYi/xuexiaoyi-to-xuexitong-tampermonkey-proxy
     """
-    DEFAULT_CACHE_FILE = "../cache.json"
+    DEFAULT_CACHE_FILE = "cache.json"
 
     def __init__(self, file: str = DEFAULT_CACHE_FILE):
         self.cache_file = Path(file)

--- a/config_template.ini
+++ b/config_template.ini
@@ -50,6 +50,18 @@ model=
 min_interval_seconds=0
 ; 可选配置请求大模型时使用的代理，填写示例：http://examples.com
 http_proxy=
+
+;硅基流动AI专属配置，以siliconflow开头的
+;硅基流动获取token的地址https://cloud.siliconflow.cn/account/ak
+siliconflow_key = 
+;可选模型deepseek-ai/DeepSeek-R1;deepseek-ai/DeepSeek-V3等，这里查看https://docs.siliconflow.cn/cn/api-reference/chat-completions/chat-completions
+siliconflow_model = deepseek-ai/DeepSeek-R1
+; 可选自定义端点
+siliconflow_endpoint = https://api.siliconflow.cn/v1/chat/completions
+
+;请求间隔时间
+min_interval_seconds = 3
+
 ; 用于判断判断题对应的选项，不要留有空格，不要留有引号，逗号为英文逗号
 true_list=正确,对,√,是
 false_list=错误,错,×,否,不对,不正确
@@ -65,3 +77,4 @@ url=
 ; https://sctapi.ftqq.com/****************.send Server酱
 ; https://qmsg.zendee.cn/send/**************** Qmsg酱
 ; https://api.day.app/**************/ Bark的高级用法请自行查阅app与其文档的说明（高级用法不一定能行，没测试过）
+

--- a/config_template.ini
+++ b/config_template.ini
@@ -58,7 +58,6 @@ siliconflow_key =
 siliconflow_model = deepseek-ai/DeepSeek-R1
 ; 可选自定义端点
 siliconflow_endpoint = https://api.siliconflow.cn/v1/chat/completions
-
 ;请求间隔时间
 min_interval_seconds = 3
 

--- a/config_template.ini
+++ b/config_template.ini
@@ -19,6 +19,7 @@ notopen_action = retry
 ; 2. TikuLike(LIKE知识库 https://www.datam.site/)
 ; 3. TikuAdapter(开源项目 https://github.com/DokiDoki1103/tikuAdapter)
 ; 4. AI(需自行寻找兼容openai格式的API Endpoint和Key)
+; 5. SiliconFlow(硅基流动AI：https://siliconflow.cn/)
 provider=TikuYanxi
 ; 是否提交答题，填写false表示答完题后不提交而是保存搜到的题目，随后你可以自行前往学习通修改或提交
 ; 填写true表示达到最低题库覆盖率提交，没达到只保存搜到的题目，进入下一章节，不保证正确率！不正确的填写会被视为false


### PR DESCRIPTION
主要有两点，硅基流动增加了token的限制防止在Deepseek-r1模型下答题失败，从512增加到4096。把答题缓存cache.json的路径改回了项目原来的位置（之前我自己用的时候改成了上级目录，这次改回了你原来的位置）