### PR TITLE
Fix Python version specification

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,8 @@ name = "chaoxing"
 version = "3.1.3"
 description = "超星学习通/超星尔雅/泛雅超星全自动无人值守完成任务点"
 readme = "README.md"
-requires-python = ">=3.10"
+license = { file = "LICENSE" }
+requires-python = ">=3.10,<4.0"
 dependencies = [
     "argparse>=1.4.0",
     "beautifulsoup4>=4.13.3",


### PR DESCRIPTION
### 概述

使用 Poetry 解析依赖时发生错误：

```txt
The current project's supported Python range (>=3.10) is not compatible with some of the required packages Python requirement:
  - loguru requires Python <4.0,>=3.5, so it will not be installable for Python >=4.0

Because no versions of loguru match >0.7.3
 and loguru (0.7.3) requires Python <4.0,>=3.5, loguru is forbidden.
So, because chaoxing depends on loguru (>=0.7.3), version solving failed.
```

此 PR 对 pyproject.toml 作出修改：

- 规定了 Python 版本 <4.0
- 添加了 license 字段
