### PR TITLE
fix:修复 get_job_list 任务卡片数大于3时遗漏任务点的问题

### DIFF
--- a/api/base.py
+++ b/api/base.py
@@ -166,6 +166,10 @@ class Chaoxing:
             "0",
             "1",
             "2",
+            "3",
+            "4",
+            "5",
+            "6",
         ]:  # 学习界面任务卡片数, 很少有3个的, 但是对于章节解锁任务点少一个都不行, 可以从API /mooc-ans/mycourse/studentstudyAjax获取值, 或者干脆直接加, 但二者都会造成额外的请求
             _url = f"https://mooc1.chaoxing.com/mooc-ans/knowledge/cards?clazzid={_clazzid}&courseid={_courseid}&knowledgeid={_knowledgeid}&num={_possible_num}&ut=s&cpi={_cpi}&v=20160407-3&mooc2=1"
             logger.trace("开始读取章节所有任务点...")


### PR DESCRIPTION
问题描述：
原有代码只遍历了任务卡片数为0、1、2的情况，实际部分章节任务点数大于3，导致部分任务点无法获取。
![image](https://github.com/user-attachments/assets/45ad3fa6-fc2d-470e-9b37-caf4b1c07fd4)
<img width="466" alt="image" src="https://github.com/user-attachments/assets/3f79f372-fe37-4e5d-bd6d-3bd3a51a1923" />


修复方案：
将遍历范围扩展到0-6，确保所有任务点都能被正确获取。