### PR TITLE
fix(cookies): 修复了使用 cookie 登录时出错的 bug

### DIFF
--- a/api/cookies.py
+++ b/api/cookies.py
@@ -11,7 +11,7 @@ def save_cookies(session: requests.Session):
     with open(gc.COOKIES_PATH, "w") as f:
         for k, v in session.cookies.items():
             buffer += f"{k}={v};"
-        buffer.removesuffix(";")
+        buffer = buffer.removesuffix(";")
         f.write(buffer)
 
 
@@ -24,5 +24,6 @@ def use_cookies() -> dict:
         buffer=f.read()
         for item in buffer.split(";"):
             k, v = item.split("=")
+            v = v.removesuffix("\n")
             cookies[k] = v
     return cookies


### PR DESCRIPTION
- 修复了保存 cookie 时，并未删除最后一个分号的 bug

- 修复了从浏览器拷贝 cookie 到 cookie.txt 中并使用 config 登录时，最后一个键值对的值中可能包含换行符导致的 ValueError