### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.11-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
Dockerfile镜像使用Python:3.11-slim才能使用typing.Self，以下为Python:3.10-slim启动容器报错： Traceback (most recent call last):
  File "/app/main.py", line 12, in <module>
    from api.base import Chaoxing, Account
  File "/app/api/base.py", line 4, in <module>
    from typing import Self
ImportError: cannot import name 'Self' from 'typing' (/usr/local/lib/python3.10/typing.py) exit status 1