### PR TITLE
更新Dockerfile和pyproject.toml，升级Python版本至3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.13-slim
 
 WORKDIR /app
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "3.1.3"
 description = "超星学习通/超星尔雅/泛雅超星全自动无人值守完成任务点"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.11,<4.0"
+requires-python = ">=3.13,<4.0"
 dynamic = ["dependencies"]
 
 [tool.setuptools]


### PR DESCRIPTION
此pr用于解决issue #541 提到的无法从queue中导入ShutDown，由于这是从3.13版本开始引入的特性。