### PR TITLE
chore:action use x64

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,8 +13,8 @@ jobs:
       matrix:
         include:
           - os: windows-latest
-            architecture: 'x86'
-            name: 'win32'
+            architecture: 'x64'
+            name: 'win64'
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
 用三十二位打包出来的会报错没有tqdm，见#553 。
看之前action的日志ddddocr依赖onnxruntime没有找到合适的版本，导致整个安装过程终止，因此tqdm实际上并没有被安装
改用64位就正常了