### PR TITLE
Fix: 修复了不正确答案被缓存

### DIFF
--- a/api/answer.py
+++ b/api/answer.py
@@ -225,9 +225,9 @@ class Tiku:
             answer = self._query(q_info)
             if answer:
                 answer = answer.strip()
-                cache_dao.add_cache(q_info['title'], answer)
                 logger.info(f"从{self.name}获取答案：{q_info['title']} -> {answer}")
                 if check_answer(answer, q_info['type'], self):
+                    cache_dao.add_cache(q_info['title'], answer)
                     return answer
                 else:
                     logger.info(f"从{self.name}获取到的答案类型与题目类型不符，已舍弃")


### PR DESCRIPTION
获取到的答案不符合也会被缓存起来，
而query答案又先从缓存获取，而不是调用api，导致我想换api答之前没搜到的题要先清缓存