### PR TITLE
fix: 修复Job缺失时的报错，添加默认任务数量

### DIFF
--- a/main.py
+++ b/main.py
@@ -263,6 +263,9 @@ class ChapterTask:
 
 class JobProcessor:
     def __init__(self, chaoxing: Chaoxing, course: dict[str, Any], tasks: list[ChapterTask], config: dict[str, Any]):
+        if "jobs" not in config or not config["jobs"]:
+            config["jobs"] = 4
+        
         self.chaoxing = chaoxing
         self.course = course
         self.speed = config["speed"]


### PR DESCRIPTION
#567 修复
请一并删除我先前错误提交的pr，谢谢你

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Job processor now defaults to 4 parallel workers when the jobs configuration is not specified or is empty, ensuring consistent processing behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->