### PR TITLE
fix: add chardet to resolve RequestsDependencyWarning in PyInstaller …

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
           pip install pyinstaller
 
       - name: Build win bin
-        run: pyinstaller -F main.py -n 'chaoxing' --add-data "resource;resource"
+        run: pyinstaller -F main.py -n 'chaoxing' --add-data "resource;resource" --hidden-import=chardet
 
       - name: Create release package
         run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ openai>=1.109.1
 tqdm>=4.67.1
 httpx>=0.28.1
 urllib3>=2.5.0
+chardet>=3.0.2,<6.0.0


### PR DESCRIPTION
## 问题描述

使用 PyInstaller 打包后的 exe 运行时出现警告：
<img width="1586" height="374" alt="屏幕截图 2026-03-06 154946" src="https://github.com/user-attachments/assets/34ec8629-86fc-47ba-8878-bebfd1006d0d" />

```
requests\__init__.py:86: RequestsDependencyWarning: 
Unable to find acceptable character detection dependency (chardet or charset_normalizer).
```

## 根因分析

`requests` 库在初始化时会尝试导入 `charset_normalizer` 或 `chardet` 作为字符编码检测依赖。

项目依赖的 `charset_normalizer>=3.4` 包含 mypyc 编译的 `.pyd` 扩展文件（`cd.cp313-win_amd64.pyd`、`md.cp313-win_amd64.pyd`），这些编译扩展在 PyInstaller 的 frozen 环境中**无法正常加载**，导致 `import charset_normalizer` 失败，`requests` 回退到警告分支。

即使使用 `--collect-all charset_normalizer` 或 `--hidden-import=charset_normalizer`，该问题仍然存在。

## 修复方案

添加 `chardet` 作为替代的字符检测库

## 验证结果

- ✅ 本地使用 `uv` + PyInstaller 打包成功
- ✅  [Github Action](https://github.com/tooplick/chaoxing/actions/runs/22755464643/job/65998929142) 打包成功
- ✅ 打包后的 exe 运行时 **不再出现** `RequestsDependencyWarning`
- ✅ `chardet==5.2.0` 版本符合 `requests` 要求的 `>=3.0.2, <6.0.0` 范围
