### PR TITLE
fix: 兼容 DeepSeek V4 默认思考模式

### DIFF
--- a/api/answer.py
+++ b/api/answer.py
@@ -768,6 +768,7 @@ class AI(Tiku):
         options = "\n".join(cleaned_options)
         # 判断题目类型
         self._wait_for_interval()
+        self.last_request_time = time.time()
         if q_info['type'] == "single":
             completion = client.chat.completions.create(**self._completion_kwargs(
                 model = self.model,
@@ -840,7 +841,6 @@ class AI(Tiku):
             ))
 
         try:
-            self.last_request_time = time.time()
             response = json.loads(remove_md_json_wrapper(completion.choices[0].message.content))
             sep = "\n"
             return sep.join(response['Answer']).strip()
@@ -867,8 +867,10 @@ class AI(Tiku):
                 client = OpenAI(http_client=httpx_client, base_url=self.endpoint, api_key=self.key)
             else:
                 client = OpenAI(base_url=self.endpoint, api_key=self.key)
-            
+
             # 发送一个简单的测试请求
+            self._wait_for_interval()
+            self.last_request_time = time.time()
             completion = client.chat.completions.create(**self._completion_kwargs(
                 model=self.model,
                 messages=[

--- a/api/answer.py
+++ b/api/answer.py
@@ -729,6 +729,26 @@ class AI(Tiku):
         self.name = 'AI大模型答题'
         self.last_request_time = None
 
+    def _is_deepseek_v4(self) -> bool:
+        return (
+            'api.deepseek.com' in (self.endpoint or '').lower()
+            and (self.model or '').lower().startswith('deepseek-v4')
+        )
+
+    def _completion_kwargs(self, **kwargs):
+        if self._is_deepseek_v4():
+            # DeepSeek V4 defaults to thinking mode, which can leave message.content empty.
+            kwargs['extra_body'] = {'thinking': {'type': 'disabled'}}
+        return kwargs
+
+    def _wait_for_interval(self):
+        if self.last_request_time:
+            interval_time = time.time() - self.last_request_time
+            if interval_time < self.min_interval_seconds:
+                sleep_time = self.min_interval_seconds - interval_time
+                logger.debug(f"API请求间隔过短, 等待 {sleep_time} 秒")
+                time.sleep(sleep_time)
+
     def _query(self, q_info: dict):
         def remove_md_json_wrapper(md_str):
             # 使用正则表达式匹配Markdown代码块并提取内容
@@ -747,8 +767,9 @@ class AI(Tiku):
         cleaned_options = [re.sub(r"^[A-Z]\s*", "", option) for option in options_list]
         options = "\n".join(cleaned_options)
         # 判断题目类型
+        self._wait_for_interval()
         if q_info['type'] == "single":
-            completion = client.chat.completions.create(
+            completion = client.chat.completions.create(**self._completion_kwargs(
                 model = self.model,
                 messages=[
                     {
@@ -760,9 +781,9 @@ class AI(Tiku):
                         "content": f"题目：{q_info['title']}\n选项：{options}"
                     }
                 ]
-            )
+            ))
         elif q_info['type'] == 'multiple':
-            completion = client.chat.completions.create(
+            completion = client.chat.completions.create(**self._completion_kwargs(
                 model = self.model,
                 messages=[
                     {
@@ -774,9 +795,9 @@ class AI(Tiku):
                         "content": f"题目：{q_info['title']}\n选项：{options}"
                     }
                 ]
-            )
+            ))
         elif q_info['type'] == 'completion':
-            completion = client.chat.completions.create(
+            completion = client.chat.completions.create(**self._completion_kwargs(
                 model = self.model,
                 messages=[
                     {
@@ -788,9 +809,9 @@ class AI(Tiku):
                         "content": f"题目：{q_info['title']}"
                     }
                 ]
-            )
+            ))
         elif q_info['type'] == 'judgement':
-            completion = client.chat.completions.create(
+            completion = client.chat.completions.create(**self._completion_kwargs(
                 model = self.model,
                 messages=[
                     {
@@ -802,9 +823,9 @@ class AI(Tiku):
                         "content": f"题目：{q_info['title']}"
                     }
                 ]
-            )
+            ))
         else:
-            completion = client.chat.completions.create(
+            completion = client.chat.completions.create(**self._completion_kwargs(
                 model = self.model,
                 messages=[
                     {
@@ -816,15 +837,9 @@ class AI(Tiku):
                         "content": f"题目：{q_info['title']}"
                     }
                 ]
-            )
+            ))
 
         try:
-            if self.last_request_time:
-                interval_time = time.time() - self.last_request_time
-                if interval_time < self.min_interval_seconds:
-                    sleep_time = self.min_interval_seconds - interval_time
-                    logger.debug(f"API请求间隔过短, 等待 {sleep_time} 秒")
-                    time.sleep(sleep_time)
             self.last_request_time = time.time()
             response = json.loads(remove_md_json_wrapper(completion.choices[0].message.content))
             sep = "\n"
@@ -854,7 +869,7 @@ class AI(Tiku):
                 client = OpenAI(base_url=self.endpoint, api_key=self.key)
             
             # 发送一个简单的测试请求
-            completion = client.chat.completions.create(
+            completion = client.chat.completions.create(**self._completion_kwargs(
                 model=self.model,
                 messages=[
                     {
@@ -862,8 +877,8 @@ class AI(Tiku):
                         'content': '你好，请回答：1+1 等于几？只回答数字。'
                     }
                 ],
-                max_tokens=10
-            )
+                max_tokens=64
+            ))
             
             if completion.choices and completion.choices[0].message.content:
                 logger.info(f'{self.name} 连接检查成功')


### PR DESCRIPTION
## 变更说明

DeepSeek V4 模型默认开启思考模式。思考模式下模型可能优先返回 `reasoning_content`，而 `message.content` 为空。当前 AI 题库只检查并解析 `message.content`，因此会出现 API 实际调用成功且消耗 tokens，但连接检查仍提示“未收到响应”的情况。

本次变更在使用官方 DeepSeek Endpoint 且模型名为 `deepseek-v4*` 时，自动传入：

```python
extra_body={"thinking": {"type": "disabled"}}
```

从而让模型稳定返回 `message.content`，避免连接检查和 JSON 答案解析失败。

同时将连接检查的 `max_tokens` 从 `10` 调整为 `64`，并将请求间隔等待逻辑移动到 API 请求发送前。

## 支持范围

- `deepseek-v4-flash`
- `deepseek-v4-pro`
- 其他以 `deepseek-v4` 开头的 DeepSeek V4 模型

该兼容逻辑仅在 Endpoint 包含 `api.deepseek.com` 时生效，不影响其他 OpenAI 兼容服务。

## 验证

```bash
python -m py_compile api/answer.py main.py
git diff --check
```

已手动验证 DeepSeek V4 默认思考模式下可能返回空 `message.content`，关闭 thinking 后可正常返回内容。

## 参考

- DeepSeek OpenAI 兼容调用说明：https://api-docs.deepseek.com/zh-cn/
- DeepSeek 思考模式说明：https://api-docs.deepseek.com/zh-cn/guides/thinking_mode


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DeepSeek V4 compatibility for AI question-answering.
  * Reworked prompt construction for single/multiple/fill/judgement questions for more consistent outputs.

* **Improvements**
  * Unified completion request handling and automatic payload injection for newer endpoints.
  * Request throttling to enforce minimum intervals between API calls.
  * Improved model connection testing and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->