### PR TITLE
fix: 通用兼容思考模型连接检查

### DIFF
--- a/api/answer.py
+++ b/api/answer.py
@@ -1131,15 +1131,18 @@ class AI(Tiku):
                         'content': '你好，请回答：1+1 等于几？只回答数字。'
                     }
                 ],
-                max_tokens=64
+                max_tokens=200
             ))
-            
-            if completion.choices and completion.choices[0].message.content:
-                logger.info(f'{self.name} 连接检查成功')
-                return True
-            else:
-                logger.error(f'{self.name} 连接检查失败：未收到响应')
-                return False
+
+            if completion.choices:
+                msg = completion.choices[0].message
+                has_content = bool(msg.content)
+                has_reasoning = bool(getattr(msg, 'reasoning_content', None))
+                if has_content or has_reasoning:
+                    logger.info(f'{self.name} 连接检查成功')
+                    return True
+            logger.error(f'{self.name} 连接检查失败：未收到响应')
+            return False
                 
         except Exception as e:
             logger.error(f'{self.name} 连接检查失败：{e}')
@@ -1258,7 +1261,7 @@ class SiliconFlow(Tiku):
                     }
                 ],
                 'stream': False,
-                'max_tokens': 10,
+                'max_tokens': 200,
                 'temperature': 0.7,
                 'top_p': 0.7,
                 'response_format': {'type': 'text'}
@@ -1273,9 +1276,13 @@ class SiliconFlow(Tiku):
             
             if response.status_code == 200:
                 result = response.json()
-                if result.get('choices') and result['choices'][0]['message']['content']:
-                    logger.info(f'{self.name} 连接检查成功')
-                    return True
+                if result.get('choices'):
+                    msg = result['choices'][0]['message']
+                    has_content = bool(msg.get('content'))
+                    has_reasoning = bool(msg.get('reasoning_content'))
+                    if has_content or has_reasoning:
+                        logger.info(f'{self.name} 连接检查成功')
+                        return True
                 else:
                     logger.error(f'{self.name} 连接检查失败：未收到有效响应')
                     return False


### PR DESCRIPTION
## 变更说明
Fix: #603 
修复 `check_llm_connection` 在使用思考模型（如 DeepSeek V4/R1、DeepSeek-V3 等）时误报"连接失败：未收到响应"的问题。

### 问题原因

思考模型会先生成 `reasoning_content`（推理过程），正文 `content` 需要更多 token 才能输出。在 `max_tokens` 过小的限制下，`content` 为空，触发误判为失败。

PR #601 通过禁用 DeepSeek V4 的思考模式解决了官方 endpoint 的场景，但使用其他 OpenAI 兼容 endpoint（如 SiliconFlow、第三方中转）时仍会复现此问题。

### 修复内容

- **AI 类**: `max_tokens` 64 → 200，同时检查 `content` 和 `reasoning_content`
- **SiliconFlow 类**: `max_tokens` 10 → 200，同时检查 `content` 和 `reasoning_content`

任意一方非空即视为连接成功，通用兼容所有思考模型。

### 验证

```bash
python -m py_compile api/answer.py
```

Closes #603

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LLM connectivity checks by expanding success criteria to recognize model responses with reasoning content, ensuring more reliable connection validation and reducing false connection failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->