### PR TITLE
fix: limit unopened chapter retries

### DIFF
--- a/main.py
+++ b/main.py
@@ -375,12 +375,12 @@ class JobProcessor:
                     logger.debug(f"unfinished task: {self.task_queue.unfinished_tasks}")
 
                 case ChapterResult.NOT_OPEN:
-                    # task.tries += 1
                     if self.config["notopen_action"] == "continue":
                         logger.warning("章节未开启: {} - {}, 正在跳过", task.course["title"], task.point["title"])
                         self.task_queue.task_done()
                         continue
 
+                    task.tries += 1
                     if task.tries >= self.max_tries:
                         logger.error(
                             "章节未开启: {} - {} 可能由于上一章节的章节检测未完成, 也可能由于该章节因为时效已关闭，"

--- a/tests/test_job_processor.py
+++ b/tests/test_job_processor.py
@@ -52,8 +52,15 @@ class JobProcessorTestCase(unittest.TestCase):
 
     def _run_with_timeout(self, processor, timeout=5.0):
         """在独立线程中运行 run()，超时抛出异常，避免旧代码无限重试导致测试永久卡死。"""
-        result = {}
-        thread = threading.Thread(target=lambda: result.setdefault("done", processor.run()))
+        exception = {}
+
+        def target():
+            try:
+                processor.run()
+            except BaseException as exc:  # noqa: BLE001 - 子线程异常需在主线程重新抛出
+                exception["exc"] = exc
+
+        thread = threading.Thread(target=target)
         thread.daemon = True
         thread.start()
         thread.join(timeout)
@@ -61,6 +68,8 @@ class JobProcessorTestCase(unittest.TestCase):
             self.fail(
                 f"JobProcessor.run() 超过 {timeout}s 未返回，疑似无限重试（Issue #612）"
             )
+        if exception:
+            raise exception["exc"]
 
     def _not_open_job_info(self):
         return {"jobs": [], "job_info": {"notOpen": True}}

--- a/tests/test_job_processor.py
+++ b/tests/test_job_processor.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+"""针对 Issue #612 的回归测试：未开放章节 (NOT_OPEN) 不再无限重试。
+
+不依赖任何第三方测试框架，仅使用 Python 标准库 unittest。
+
+main.py 使用相对的 ``from api...`` 导入，因此需要把仓库根目录
+（main.py 所在目录）加入 sys.path，使测试能在任意 cwd 下运行。
+"""
+import os
+import sys
+import threading
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import main  # noqa: E402
+
+
+class DummyChaoxing:
+    """仅提供 process_chapter 所需的最小接口，不发任何网络请求。"""
+
+    def __init__(self, job_info):
+        self.job_info = job_info
+        self.rate_limiter = _NoopRateLimiter()
+
+    def get_job_list(self, course, point):
+        return self.job_info["jobs"], self.job_info["job_info"]
+
+
+class _NoopRateLimiter:
+    def limit_rate(self, *args, **kwargs):
+        return None
+
+
+class JobProcessorTestCase(unittest.TestCase):
+    def setUp(self):
+        main.logger.remove()  # 关闭所有 handler，避免测试日志刷屏
+
+    def _make_processor(self, job_info, notopen_action="retry", max_tries=3):
+        course = {"title": "课程"}
+        point = {"title": "章节", "has_finished": False}
+        task = main.ChapterTask(index=0, point=point, course=course)
+        config = {
+            "speed": 1.0,
+            "jobs": 1,
+            "notopen_action": notopen_action,
+            "retry_interval": 0.01,
+        }
+        processor = main.JobProcessor(DummyChaoxing(job_info), [task], config)
+        processor.max_tries = max_tries
+        return processor, task
+
+    def _run_with_timeout(self, processor, timeout=5.0):
+        """在独立线程中运行 run()，超时抛出异常，避免旧代码无限重试导致测试永久卡死。"""
+        result = {}
+        thread = threading.Thread(target=lambda: result.setdefault("done", processor.run()))
+        thread.daemon = True
+        thread.start()
+        thread.join(timeout)
+        if thread.is_alive():
+            self.fail(
+                f"JobProcessor.run() 超过 {timeout}s 未返回，疑似无限重试（Issue #612）"
+            )
+
+    def _not_open_job_info(self):
+        return {"jobs": [], "job_info": {"notOpen": True}}
+
+    def _error_job_info(self):
+        # 未知任务类型会走 ERROR 分支，不依赖网络。
+        return {"jobs": [{"type": "unknown"}], "job_info": {}}
+
+    def test_not_open_does_not_retry_forever(self):
+        processor, _ = self._make_processor(self._not_open_job_info(), max_tries=3)
+        self._run_with_timeout(processor)
+
+    def test_not_open_tries_increment(self):
+        processor, task = self._make_processor(self._not_open_job_info(), max_tries=3)
+        self._run_with_timeout(processor)
+        self.assertEqual(task.tries, 3)
+
+    def test_not_open_stops_after_max_tries(self):
+        processor, task = self._make_processor(self._not_open_job_info(), max_tries=3)
+        self._run_with_timeout(processor)
+        self.assertEqual(task.tries, 3)
+        self.assertTrue(processor.task_queue.empty())
+        self.assertTrue(processor.retry_queue.empty())
+        self.assertEqual(processor.task_queue.unfinished_tasks, 0)
+
+    def test_not_open_queue_joins_normally(self):
+        for _ in range(3):
+            processor, _ = self._make_processor(self._not_open_job_info(), max_tries=3)
+            self._run_with_timeout(processor)
+
+    def test_not_open_continue_skips_without_retry(self):
+        processor, task = self._make_processor(
+            self._not_open_job_info(), notopen_action="continue", max_tries=3
+        )
+        self._run_with_timeout(processor)
+        self.assertEqual(task.tries, 0)
+        self.assertTrue(processor.retry_queue.empty())
+
+    def test_error_retry_behavior_unchanged(self):
+        processor, task = self._make_processor(self._error_job_info(), max_tries=3)
+        self._run_with_timeout(processor)
+        self.assertEqual(task.tries, 3)
+        self.assertIn(task, processor.failed_tasks)
+
+    def test_success_does_not_retry(self):
+        # 已完成章节直接 SUCCESS，不应有任何重试。
+        course = {"title": "课程"}
+        point = {"title": "章节", "has_finished": True}
+        task = main.ChapterTask(index=0, point=point, course=course)
+        config = {
+            "speed": 1.0,
+            "jobs": 1,
+            "notopen_action": "retry",
+            "retry_interval": 0.01,
+        }
+        processor = main.JobProcessor(DummyChaoxing(self._not_open_job_info()), [task], config)
+        processor.max_tries = 3
+        self._run_with_timeout(processor)
+        self.assertEqual(task.tries, 0)
+        self.assertTrue(processor.retry_queue.empty())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_job_processor.py
+++ b/tests/test_job_processor.py
@@ -1,12 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-针对 Issue #612 的回归测试：未开放章节 (NOT_OPEN) 不再无限重试.
-
-不依赖任何第三方测试框架，仅使用 Python 标准库 unittest。
-
-main.py 使用相对的 ``from api...`` 导入，因此需要把仓库根目录
-（main.py 所在目录）加入 sys.path，使测试能在任意 cwd 下运行。
-"""
+"""Issue #612 的回归测试：未开放章节不再无限重试."""
 import os
 import sys
 import threading

--- a/tests/test_job_processor.py
+++ b/tests/test_job_processor.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-"""针对 Issue #612 的回归测试：未开放章节 (NOT_OPEN) 不再无限重试。
+"""
+针对 Issue #612 的回归测试：未开放章节 (NOT_OPEN) 不再无限重试.
 
 不依赖任何第三方测试框架，仅使用 Python 标准库 unittest。
 
@@ -17,9 +18,10 @@ import main  # noqa: E402
 
 
 class DummyChaoxing:
-    """仅提供 process_chapter 所需的最小接口，不发任何网络请求。"""
+    """仅提供 process_chapter 所需的最小接口，不发任何网络请求."""
 
     def __init__(self, job_info):
+        """初始化测试替身，保存固定的任务点数据."""
         self.job_info = job_info
         self.rate_limiter = _NoopRateLimiter()
 
@@ -51,7 +53,7 @@ class JobProcessorTestCase(unittest.TestCase):
         return processor, task
 
     def _run_with_timeout(self, processor, timeout=5.0):
-        """在独立线程中运行 run()，超时抛出异常，避免旧代码无限重试导致测试永久卡死。"""
+        """在独立线程中运行 run()，超时抛出异常，避免旧代码无限重试导致测试永久卡死."""
         exception = {}
 
         def target():


### PR DESCRIPTION
Fixes #612


未开放章节（ChapterResult.NOT_OPEN）会无限重试：worker_thread 的 NOT_OPEN 分支里 task.tries += 1 被注释掉，if task.tries >= self.max_tries 恒为假，任务被反复放回 retry_queue，日志不断打印「该章节未开放」，且 task_queue.join() 永不返回，程序卡死。

根因

main.py 中 JobProcessor.worker_thread() 的 NOT_OPEN 分支缺少 task.tries += 1，与 ERROR 分支（先自增再判上限）不对称。

修复

在 NOT_OPEN 分支、continue 跳过逻辑之后补上 task.tries += 1：

- 仅真正进入重试流程时累积次数；
- notopen_action=continue 行为不变（tries 仍为 0，直接跳过）；
- 达到 max_tries 后调用 task_done() 正常结束、不再入队，join() 能返回；
- SUCCESS / ERROR 分支不受影响。

测试

新增 tests/test_job_processor.py（仅标准库 unittest，无新依赖），覆盖无限重试、tries 递增、达上限停止入队、continue 跳过、ERROR 回归，并带超时保护。本地 python -m unittest discover -s tests -v → 7/7 通过。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Skipped closed chapters now correctly count toward the configured retry limit.
  - Prevents repeated attempts after the retry limit is reached.
  - Existing retry behavior for other errors remains unchanged.
  - Processing now handles continue actions consistently when chapters are unavailable.

- **Tests**
  - Added regression coverage for retry limits, skipped chapters, continue actions, queue completion, and successful task handling.
  - Added safeguards to verify that processing completes reliably and failures are reported correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->