### PR TITLE
feat: add TikuLocal (SQLite) and Bailian (DashScope) providers, plus sign-in module

### DIFF
--- a/api/answer.py
+++ b/api/answer.py
@@ -4,6 +4,7 @@ import os
 import random
 import re
 import shutil
+import sqlite3
 import tempfile
 import threading
 import time
@@ -24,7 +25,7 @@ from api.logger import logger
 disable_warnings(exceptions.InsecureRequestWarning)
 
 __all__ = ["CacheDAO", "Tiku", "TikuFallback", "TikuYanxi", "TikuGo", "TikuLike", "TikuAdapter", "AI", "SiliconFlow",
-           "TikuManual"]
+           "TikuManual", "TikuLocal", "Bailian"]
 
 
 class CacheDAO:
@@ -252,6 +253,7 @@ class Tiku(ABC):
                 logger.info(f"从{self.name}获取答案：{q_info['title']} -> {answer}")
                 if check_answer(answer, q_info['type'], self):
                     cache_dao.add_cache(q_info['title'], answer)
+                    self._save_auto(q_info, answer)
                     return answer
                 else:
                     logger.info(f"从{self.name}获取到的答案类型与题目类型不符，已舍弃")
@@ -318,6 +320,13 @@ class Tiku(ABC):
     def _query(self, q_info: dict) -> Optional[str]:
         """
         查询接口, 交由自定义题库实现
+        """
+        pass
+
+    def _save_auto(self, q_info: dict, answer: str):
+        """
+        自动保存钩子。上游题库搜到答案后可存入本地库，默认不保存，
+        由 TikuLocal 等子类重写。
         """
         pass
 
@@ -1877,6 +1886,138 @@ class DummyTiku(Tiku):
         return None
 
 
+class TikuLocal(Tiku):
+    """本地 SQLite 题库。查询本地库；配合 _save_auto 可自动积累答案。"""
+
+    def __init__(self, config_path: Optional[str] = None):
+        super().__init__(config_path)
+        self.name = '本地题库'
+        self._db_path = None
+        self._conn = None
+
+    def _init_tiku(self):
+        self._db_path = self._conf.get(
+            'db_path',
+            os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'data', 'tiku.db')
+        )
+        os.makedirs(os.path.dirname(self._db_path), exist_ok=True)
+        self._conn = sqlite3.connect(self._db_path, check_same_thread=False)
+        self._conn.execute('''
+            CREATE TABLE IF NOT EXISTS tiku (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                question TEXT NOT NULL,
+                answer TEXT NOT NULL,
+                type TEXT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        ''')
+        self._conn.execute('CREATE UNIQUE INDEX IF NOT EXISTS idx_question ON tiku(question)')
+        self._conn.commit()
+        self._conn.execute('PRAGMA journal_mode=WAL')
+        logger.info(f'本地题库已初始化: {self._db_path}')
+
+    def _query(self, q_info: dict):
+        title = q_info.get('title', '').strip()
+        if not title or not self._conn:
+            return None
+        cur = self._conn.cursor()
+        cur.execute('SELECT answer FROM tiku WHERE question = ?', (title,))
+        row = cur.fetchone()
+        if row:
+            return row[0]
+        cur.execute('SELECT answer FROM tiku WHERE question LIKE ? LIMIT 1', (f'%{title}%',))
+        row = cur.fetchone()
+        return row[0] if row else None
+
+    def add_question(self, question: str, answer: str, q_type: str = ''):
+        try:
+            self._conn.execute(
+                'INSERT OR IGNORE INTO tiku (question, answer, type) VALUES (?, ?, ?)',
+                (question, answer, q_type)
+            )
+            self._conn.commit()
+        except Exception as e:
+            logger.debug(f'添加题目失败: {e}')
+
+    def _save_auto(self, q_info: dict, answer: str):
+        if self.name == '本地题库':
+            return
+        self.add_question(q_info['title'], answer, q_info.get('type', ''))
+
+    def stats(self) -> dict:
+        cur = self._conn.cursor()
+        cur.execute('SELECT COUNT(*) FROM tiku')
+        total = cur.fetchone()[0]
+        cur.execute('SELECT type, COUNT(*) FROM tiku GROUP BY type')
+        return {'total': total, 'by_type': dict(cur.fetchall())}
+
+    def close(self):
+        if self._conn:
+            self._conn.close()
+
+
+class Bailian(Tiku):
+    """阿里云百炼（DashScope OpenAI 兼容接口）答题实现。"""
+
+    def __init__(self, config_path: Optional[str] = None):
+        super().__init__(config_path)
+        self.name = '阿里云百炼'
+        self.last_request_time = None
+
+    def _query(self, q_info: dict):
+        def remove_md_json_wrapper(md_str):
+            pattern = r'^\s*```(?:json)?\s*(.*?)\s*```\s*$'
+            match = re.search(pattern, md_str, re.DOTALL)
+            return match.group(1).strip() if match else md_str.strip()
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json"
+        }
+        prompts = {
+            "single": "本题为单选题，请选择唯一正确答案，输出选项的具体内容而非ABCD，以JSON格式输出：{\"Answer\": [\"正确选项内容\"]}。不要输出多余内容。",
+            "multiple": "本题为多选题，请选择所有正确选项，输出选项的具体内容而非ABCD，以JSON格式输出：{\"Answer\": [\"选项1\",\"选项2\"]}。不要输出多余内容。",
+            "completion": "本题为填空题，请直接给出填空内容，以JSON格式输出：{\"Answer\": [\"答案文本\"]}。不要输出多余内容。",
+            "judgement": "本题为判断题，请回答'正确'或'错误'，以JSON格式输出：{\"Answer\": [\"正确\"]}。不要输出多余内容。",
+        }
+        system_prompt = prompts.get(q_info['type'], prompts["single"])
+        payload = {
+            "model": self.model_name,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": f"题目：{q_info['title']}\n选项：{q_info['options']}"}
+            ],
+            "stream": False,
+            "max_tokens": 4096,
+            "temperature": 0.7,
+            "top_p": 0.7,
+        }
+        if self.last_request_time:
+            interval = time.time() - self.last_request_time
+            if interval < self.min_interval:
+                time.sleep(self.min_interval - interval)
+        try:
+            response = requests.post(self.api_endpoint, headers=headers, json=payload, timeout=30)
+            self.last_request_time = time.time()
+            if response.status_code == 200:
+                result = response.json()
+                content = result['choices'][0]['message']['content']
+                parsed = json.loads(remove_md_json_wrapper(content))
+                return "\n".join(parsed['Answer']).strip()
+            logger.error(f"API请求失败：{response.status_code} {response.text}")
+            return None
+        except Exception as e:
+            logger.error(f"百炼API异常：{e}")
+            return None
+
+    def _init_tiku(self):
+        self.api_endpoint = self._conf.get(
+            'bailian_endpoint', 'https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions')
+        self.api_key = self._conf['bailian_key']
+        self.model_name = self._conf.get('bailian_model', 'qwen-plus')
+        self.min_interval = int(self._conf.get('min_interval_seconds', 3))
+
+
 PROVIDER_REGISTRY = {
     'TikuYanxi': TikuYanxi,
     'TikuGo': TikuGo,
@@ -1885,4 +2026,6 @@ PROVIDER_REGISTRY = {
     'AI': AI,
     'SiliconFlow': SiliconFlow,
     'TikuManual': TikuManual,
+    'TikuLocal': TikuLocal,
+    'Bailian': Bailian,
 }

--- a/api/sign.py
+++ b/api/sign.py
@@ -1,0 +1,164 @@
+import time
+import random
+from api.logger import logger
+
+
+class SignIn:
+    def __init__(self, session, uid, fid):
+        self.session = session
+        self.uid = uid
+        self.fid = fid
+
+    def get_active_list(self, course_id, class_id):
+        url = f"https://mobilelearn.chaoxing.com/v2/apis/active/student/activelist"
+        params = {"fid": "0", "courseId": course_id, "classId": class_id, "_": int(time.time() * 1000)}
+        resp = self.session.get(url, params=params)
+        if resp.status_code != 200:
+            return None
+        return resp.json()
+
+    def get_active_info(self, active_id):
+        url = f"https://mobilelearn.chaoxing.com/v2/apis/active/getPPTActiveInfo"
+        params = {"activeId": active_id}
+        resp = self.session.get(url, params=params)
+        if resp.status_code != 200:
+            return None
+        return resp.json().get("data")
+
+    def pre_sign(self, active_id, course_id, class_id):
+        url = "https://mobilelearn.chaoxing.com/newsign/preSign"
+        params = {
+            "courseId": course_id, "classId": class_id, "activePrimaryId": active_id,
+            "general": "1", "sys": "1", "ls": "1", "appType": "15", "uid": self.uid, "ut": "s"
+        }
+        self.session.get(url, params=params)
+        time.sleep(0.5)
+
+    def general_sign(self, active_id, name):
+        url = "https://mobilelearn.chaoxing.com/pptSign/stuSignajax"
+        params = {
+            "activeId": active_id, "uid": self.uid, "clientip": "",
+            "latitude": "-1", "longitude": "-1", "appType": "15",
+            "fid": self.fid, "name": name
+        }
+        resp = self.session.get(url, params=params)
+        return resp.text
+
+    def location_sign(self, active_id, name, lat, lon, address):
+        url = "https://mobilelearn.chaoxing.com/pptSign/stuSignajax"
+        params = {
+            "activeId": active_id, "uid": self.uid, "clientip": "",
+            "latitude": lat, "longitude": lon, "appType": "15",
+            "fid": self.fid, "name": name, "address": address, "ifTiJiao": "1"
+        }
+        resp = self.session.get(url, params=params)
+        return resp.text
+
+    def photo_sign(self, active_id, name, object_id):
+        url = "https://mobilelearn.chaoxing.com/pptSign/stuSignajax"
+        params = {
+            "activeId": active_id, "uid": self.uid, "clientip": "",
+            "latitude": "-1", "longitude": "-1", "appType": "15",
+            "fid": self.fid, "objectId": object_id, "name": name
+        }
+        resp = self.session.get(url, params=params)
+        return resp.text
+
+    def scan_courses(self, courses, sign_config):
+        logger.info("正在查询有效签到活动...")
+        for course in courses:
+            try:
+                data = self.get_active_list(course["courseId"], course["clazzId"])
+                if not data or not data.get("data"):
+                    continue
+                active_list = data["data"].get("activeList", [])
+                if not active_list:
+                    continue
+                act = active_list[0]
+                other_id = int(act.get("otherId", -1))
+                if other_id < 0 or other_id > 5 or act.get("status") != 1:
+                    continue
+                start_time = act.get("startTime", 0)
+                if (time.time() * 1000 - start_time) / 1000 > 7200:
+                    continue
+                name = act.get("nameOne", "签到")
+                active_id = str(act["id"])
+                logger.info(f"检测到签到: {name} ({course['title']})")
+                return self._handle_sign(active_id, name, other_id, course, sign_config)
+            except Exception as e:
+                logger.debug(f"查询课程 {course.get('title')} 签到失败: {e}")
+        return None
+
+    def _handle_sign(self, active_id, name, sign_type, course, config):
+        info = self.get_active_info(active_id)
+        if not info:
+            logger.error(f"获取签到信息失败")
+            return None
+
+        self.pre_sign(active_id, course["courseId"], course["clazzId"])
+
+        if sign_type == 0:
+            if info.get("ifphoto") == 1:
+                return self._do_photo(active_id, name, info, config)
+            return self._do_general(active_id, name)
+        elif sign_type == 2:
+            logger.warning("二维码签到需手动扫码，跳过")
+            return None
+        elif sign_type == 3:
+            return self._do_gesture(active_id, name, info)
+        elif sign_type == 4:
+            return self._do_location(active_id, name, info, config)
+        elif sign_type == 5:
+            return self._do_code(active_id, name, info)
+        return None
+
+    def _do_general(self, active_id, name):
+        result = self.general_sign(active_id, name)
+        msg = "签到成功" if result == "success" else f"签到失败: {result}"
+        logger.info(f"[普通] {msg}")
+        return msg
+
+    def _do_gesture(self, active_id, name):
+        result = self.general_sign(active_id, name)
+        msg = "签到成功" if result == "success" else f"签到失败: {result}"
+        logger.info(f"[手势] {msg}")
+        return msg
+
+    def _do_location(self, active_id, name, info, config):
+        lat = config.get("latitude", "30.1234")
+        lon = config.get("longitude", "120.5678")
+        address = config.get("address", "学校")
+        result = self.location_sign(active_id, name, lat, lon, address)
+        msg = "签到成功" if result == "success" else f"签到失败: {result}"
+        logger.info(f"[位置] {msg}")
+        return msg
+
+    def _do_photo(self, active_id, name, info, config):
+        object_id = config.get("photo_object_id", "")
+        if not object_id:
+            logger.warning("拍照签到需要准备照片，请上传到超星云盘命名为 0.jpg")
+            return None
+        result = self.photo_sign(active_id, name, object_id)
+        msg = "签到成功" if result == "success" else f"签到失败: {result}"
+        logger.info(f"[拍照] {msg}")
+        return msg
+
+    def _do_code(self, active_id, name, info):
+        code = input("请输入签到码: ").strip()
+        if not code:
+            return None
+        result = self.general_sign(active_id, name + f"&code={code}")
+        msg = "签到成功" if result == "success" else f"签到失败: {result}"
+        logger.info(f"[签到码] {msg}")
+        return msg
+
+    def monitor(self, courses, sign_config, interval=30):
+        logger.info(f"签到监控已启动，每 {interval} 秒检查一次...")
+        try:
+            while True:
+                result = self.scan_courses(courses, sign_config)
+                if result:
+                    logger.info(f"签到结果: {result}")
+                time.sleep(interval)
+        except KeyboardInterrupt:
+            logger.info("签到监控已停止")


### PR DESCRIPTION
## Changes
- Add `TikuLocal`: local SQLite question bank with WAL mode, fuzzy match, and `_save_auto` hook to accumulate answers automatically
- Add `Bailian`: Alibaba Cloud DashScope (OpenAI-compatible) answer provider
- Add `api/sign.py`: sign-in module (normal/gesture/location/photo/code)
- Add `_save_auto` hook to base `Tiku.query` so upstream providers can persist answers to local DB

All changes are additive and do not modify existing providers or the CLI interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added local SQLite-based question-and-answer storage, including lookup, statistics, and automatic saving of generated answers.
  * Added support for Alibaba DashScope-compatible AI chat completions with configurable models, endpoints, throttling, and JSON responses.
  * Added automated classroom sign-in monitoring for general, gesture, location, photo, and code-based activities.
  * QR-code sign-ins are detected and skipped with a warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->